### PR TITLE
Fix snake_case to snakecase in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,14 +90,14 @@ Strings::Case.snakecase("foo bar baz")
 It will transform any string into expected case:
 
 ```ruby
-Strings::Case.snake_case("supports IPv6 on iOS?")
+Strings::Case.snakecase("supports IPv6 on iOS?")
 # => "supports_ipv6_on_ios"
 ```
 
 You can apply case transformations to Unicode characters:
 
 ```ruby
-Strings::Case.snake_case("ЗдравствуйтеПривет")
+Strings::Case.snakecase("ЗдравствуйтеПривет")
 # => "здравствуйте_привет"
 ```
 


### PR DESCRIPTION
There is no  method, it's called #snakecase in: https://github.com/piotrmurach/strings-case/blob/master/lib/strings/case.rb#L208

### Describe the change
Fixed typos in README `#snake_case` -> `#snakecase`

### Why are we doing this?
It's confusing

### Benefits
Example code will work correctly.

### Drawbacks
Well, the change is perfect, no drawbacks ;)

### Requirements
Put an X between brackets on each line if you have done the item:
[] Tests written & passing locally?
[] Code style checked?
[] Rebased with `master` branch?
[] Documentation updated?
